### PR TITLE
Added CloudKit

### DIFF
--- a/Treyana.xcodeproj/project.pbxproj
+++ b/Treyana.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C9D65F6D2463A69F001BAEFF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C9D65F6B2463A69F001BAEFF /* LaunchScreen.storyboard */; };
 		C9D65F752463A8E8001BAEFF /* TestDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D65F742463A8E8001BAEFF /* TestDataViewController.swift */; };
 		C9D65F7B2463B93E001BAEFF /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D65F7A2463B93E001BAEFF /* TestData.swift */; };
+		C9D7ECCC24A0346C006336C1 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D7ECCB24A0346C006336C1 /* Record.swift */; };
 		C9E29586246D01BB00901D7F /* TestDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E29585246D01BB00901D7F /* TestDataManager.swift */; };
 		C9EB236C24764E2900346C19 /* TestDataTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB236B24764E2800346C19 /* TestDataTableViewController.swift */; };
 		C9FCEEDA24652AFA001957B8 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FCEED924652AF9001957B8 /* Constants.swift */; };
@@ -40,6 +41,7 @@
 		C9D65F6E2463A69F001BAEFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C9D65F742463A8E8001BAEFF /* TestDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataViewController.swift; sourceTree = "<group>"; };
 		C9D65F7A2463B93E001BAEFF /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
+		C9D7ECCB24A0346C006336C1 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		C9E29585246D01BB00901D7F /* TestDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataManager.swift; sourceTree = "<group>"; };
 		C9EB236B24764E2800346C19 /* TestDataTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDataTableViewController.swift; sourceTree = "<group>"; };
 		C9FCEED924652AF9001957B8 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 		C9D65F7C2463B944001BAEFF /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				C9D7ECCB24A0346C006336C1 /* Record.swift */,
 				C9D65F7A2463B93E001BAEFF /* TestData.swift */,
 				C9E29585246D01BB00901D7F /* TestDataManager.swift */,
 				C9317A27246E82C8009D3E39 /* JSONFileManager.swift */,
@@ -226,6 +229,7 @@
 				C986C5F425665C1300003A83 /* Alert.swift in Sources */,
 				C986C5F625665D5000003A83 /* AlertError.swift in Sources */,
 				C9FCEEDA24652AFA001957B8 /* Constants.swift in Sources */,
+				C9D7ECCC24A0346C006336C1 /* Record.swift in Sources */,
 				C9A1E0F0248F5BF40090AA95 /* CloudService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Treyana.xcodeproj/project.pbxproj
+++ b/Treyana.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C919E96A247E265400517288 /* String+count.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919E969247E265400517288 /* String+count.swift */; };
+		C929F649248F517E00E6FEAD /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C929F648248F517E00E6FEAD /* CloudKit.framework */; };
 		C9317A28246E82C8009D3E39 /* JSONFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9317A27246E82C8009D3E39 /* JSONFileManager.swift */; };
 		C986C5F425665C1300003A83 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986C5F325665C1300003A83 /* Alert.swift */; };
 		C986C5F625665D5000003A83 /* AlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986C5F525665D5000003A83 /* AlertError.swift */; };
@@ -25,6 +26,8 @@
 
 /* Begin PBXFileReference section */
 		C919E969247E265400517288 /* String+count.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+count.swift"; sourceTree = "<group>"; };
+		C929F646248F517C00E6FEAD /* Treyana.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Treyana.entitlements; sourceTree = "<group>"; };
+		C929F648248F517E00E6FEAD /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		C9317A27246E82C8009D3E39 /* JSONFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFileManager.swift; sourceTree = "<group>"; };
 		C986C5F325665C1300003A83 /* Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 		C986C5F525665D5000003A83 /* AlertError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertError.swift; sourceTree = "<group>"; };
@@ -47,6 +50,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C929F649248F517E00E6FEAD /* CloudKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,6 +89,7 @@
 			children = (
 				C9D65F5F2463A69E001BAEFF /* Treyana */,
 				C9D65F5E2463A69E001BAEFF /* Products */,
+				C929F647248F517E00E6FEAD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -221,6 +226,7 @@
 				C986C5F425665C1300003A83 /* Alert.swift in Sources */,
 				C986C5F625665D5000003A83 /* AlertError.swift in Sources */,
 				C9FCEEDA24652AFA001957B8 /* Constants.swift in Sources */,
+				C9A1E0F0248F5BF40090AA95 /* CloudService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,6 +370,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Treyana/Treyana.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = HBV336R3WK;
 				INFOPLIST_FILE = Treyana/Info.plist;
@@ -382,6 +389,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Treyana/Treyana.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = HBV336R3WK;
 				INFOPLIST_FILE = Treyana/Info.plist;

--- a/Treyana/Controllers/TestDataTableViewController.swift
+++ b/Treyana/Controllers/TestDataTableViewController.swift
@@ -25,14 +25,14 @@ class TestDataTableViewController: UIViewController {
     
     @IBAction func pressedAddData(_ sender: UIBarButtonItem) {
         testDataManager.createNewTestDataSet()
-        performSegue(withIdentifier: "ListToData", sender: self)
+        performSegue(withIdentifier: Constants.SegueIdentifier.listToData, sender: self)
     }
 }
 
 //MARK: - TestDataTableViewController extension
 extension TestDataTableViewController {
     fileprivate func tableReload() {
-        NotificationCenter.default.addObserver(self, selector: #selector(loadList), name: NSNotification.Name(rawValue: "load"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(loadList), name: NSNotification.Name(rawValue: Constants.Notification.name), object: nil)
     }
     
     @objc fileprivate func loadList(notification: NSNotification){
@@ -68,7 +68,7 @@ extension TestDataTableViewController: UITableViewDataSource {
 extension TestDataTableViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         selectedRow = indexPath.row
-        performSegue(withIdentifier: "ListToData", sender: self)
+        performSegue(withIdentifier: Constants.SegueIdentifier.listToData, sender: self)
     }
         
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {

--- a/Treyana/Controllers/TestDataTableViewController.swift
+++ b/Treyana/Controllers/TestDataTableViewController.swift
@@ -21,6 +21,7 @@ class TestDataTableViewController: UIViewController {
         
         testDataTableView.dataSource = self
         testDataTableView.delegate = self
+        CloudService.loadTestData()
     }
     
     @IBAction func pressedAddData(_ sender: UIBarButtonItem) {

--- a/Treyana/Controllers/TestDataViewController.swift
+++ b/Treyana/Controllers/TestDataViewController.swift
@@ -37,6 +37,22 @@ class TestDataViewController: UIViewController {
         displayCounts(for: testString)
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        guard let url = JSONFileManager.fileURL else {
+            let alert = UIAlertController(title: "ERROR", message: "File could not be found!", preferredStyle: .alert)
+            let action = UIAlertAction(title: "OK", style: .cancel, handler: nil)
+            alert.addAction(action)
+            
+            present(alert, animated: true)
+            
+            return
+        }
+        
+        CloudService.saveToCloud(url: url)
+    }
+    
     @IBAction func shareButtonTapped(_ sender: UIBarButtonItem) {
         displayShareSheet()
     }

--- a/Treyana/Controllers/TestDataViewController.swift
+++ b/Treyana/Controllers/TestDataViewController.swift
@@ -50,7 +50,7 @@ extension TestDataViewController {
     }
     
     fileprivate func postNotification() {
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "load"), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: Constants.Notification.name), object: nil)
     }
     
     fileprivate func displayCounts(for string: String) {

--- a/Treyana/Delegates/SceneDelegate.swift
+++ b/Treyana/Delegates/SceneDelegate.swift
@@ -33,8 +33,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
+        if let url = JSONFileManager.fileURL {
+            CloudService.saveToCloud(url: url)
+        }
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {

--- a/Treyana/Model/JSONFileManager.swift
+++ b/Treyana/Model/JSONFileManager.swift
@@ -32,6 +32,7 @@ struct JSONFileManager {
         
         do {
             try encoder.encode(testData).write(to: url)
+            cloudService.saveToCloud(url: url)
         } catch {
             print(error)
         }

--- a/Treyana/Model/JSONFileManager.swift
+++ b/Treyana/Model/JSONFileManager.swift
@@ -32,7 +32,6 @@ struct JSONFileManager {
         
         do {
             try encoder.encode(testData).write(to: url)
-            cloudService.saveToCloud(url: url)
         } catch {
             print(error)
         }

--- a/Treyana/Model/Record.swift
+++ b/Treyana/Model/Record.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  Treyana
+//
+//  Created by Matt M Smith on 6/21/20.
+//  Copyright © 2020 Matt. All rights reserved.
+//
+
+import Foundation
+import CloudKit
+
+class Record {
+    var asset: CKAsset?
+}

--- a/Treyana/Model/TestDataManager.swift
+++ b/Treyana/Model/TestDataManager.swift
@@ -25,7 +25,7 @@ struct TestDataManager {
         let newStringDataArray = returnNewStringDataArray { (stringDataArray) in
             let lastID = stringDataArray.last?.id ?? 0
             let id = stringDataArray.count != 0 ? lastID + 1 : 0
-            let stringData = StringData(id: id, title: "Test Set \(id)", testString: "")
+            let stringData = StringData(id: id, title: Constants.TestSet.title + " \(id)", testString: "")
             
             stringDataArray.append(stringData)
             

--- a/Treyana/Network/CloudService.swift
+++ b/Treyana/Network/CloudService.swift
@@ -10,8 +10,9 @@ import Foundation
 import CloudKit
 
 struct CloudService {
+    private static let record = CKRecord(recordType: Constants.Cloud.recordType)
+    
     static func saveToCloud(url: URL) {
-        let record = CKRecord(recordType: Constants.Cloud.recordType)
         let container = CKContainer.default()
         let database = container.privateCloudDatabase
         
@@ -19,9 +20,49 @@ struct CloudService {
         
         database.save(record) { (_, error) in
             if let error = error {
+                print("ERROR: \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+    
+    static func loadTestData() {
+        let savedRecord = Record()
+        let pred = NSPredicate(value: true)
+        let sort = NSSortDescriptor(key: Constants.Cloud.modificationDate, ascending: false)
+        let query = CKQuery(recordType: Constants.Cloud.recordType, predicate: pred)
+        query.sortDescriptors = [sort]
+        
+        let operation = CKQueryOperation(query: query)
+        operation.desiredKeys = [Constants.Cloud.modificationDate, Constants.Cloud.testStrings]
+        operation.resultsLimit = 1
+        
+        operation.recordFetchedBlock = { cloudRecord in
+            if let cloudDate = cloudRecord.modificationDate, let recordDate = record.modificationDate {
+                if cloudDate > recordDate {
+                    savedRecord.asset = cloudRecord[Constants.Cloud.testStrings]
+                    if let oldFileURL = JSONFileManager.fileURL, let newFileURL = savedRecord.asset?.fileURL {
+                        do {
+                            _ = try FileManager.default.replaceItemAt(oldFileURL, withItemAt: newFileURL, backupItemName: nil, options: .usingNewMetadataOnly)
+                        } catch {
+                            print(error.localizedDescription)
+                        }
+                    } else {
+                        print("URL FAIL")
+                    }
+                }
+            } else {
+                print("DATE FAIL")
+            }
+        }
+        
+        operation.queryCompletionBlock = { _, error in
+            if let error = error {
                 print(error.localizedDescription)
                 return
             }
         }
+        
+        CKContainer.default().privateCloudDatabase.add(operation)
     }
 }

--- a/Treyana/Network/CloudService.swift
+++ b/Treyana/Network/CloudService.swift
@@ -10,7 +10,7 @@ import Foundation
 import CloudKit
 
 struct CloudService {
-    func saveToCloud(url: URL) {
+    static func saveToCloud(url: URL) {
         let record = CKRecord(recordType: Constants.Cloud.recordType)
         let container = CKContainer.default()
         let database = container.privateCloudDatabase

--- a/Treyana/Network/CloudService.swift
+++ b/Treyana/Network/CloudService.swift
@@ -1,0 +1,27 @@
+//
+//  CloudService.swift
+//  Treyana
+//
+//  Created by Matt M Smith on 6/8/20.
+//  Copyright © 2020 Matt. All rights reserved.
+//
+
+import Foundation
+import CloudKit
+
+struct CloudService {
+    func saveToCloud(url: URL) {
+        let record = CKRecord(recordType: Constants.Cloud.recordType)
+        let container = CKContainer.default()
+        let database = container.privateCloudDatabase
+        
+        record[Constants.Cloud.testStrings] = CKAsset(fileURL: url)
+        
+        database.save(record) { (_, error) in
+            if let error = error {
+                print(error.localizedDescription)
+                return
+            }
+        }
+    }
+}

--- a/Treyana/Treyana.entitlements
+++ b/Treyana/Treyana.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.mattstats.Treyana</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
I've added the ability to save data using CloudKit. I do have a question though. Right now the app writes to the json file when either a user creates a new data set, edits the title, edits the test string, or deletes a set of test data. The test string is saved whenever a change is made in the textView (TestDataViewController - line 90). This seems like overkill to me, because of how many times the app will attempt to ping the network. I can move the functionality out of the function it's being called in (JSONFileManager - line 90), but then I'll have to call it in more than one place. Honestly, I think I should move it to save all the attempts that will be made on the network, but I'd like your opinion. I know this isn't some game changing app that's going to have millions of users, but I would like to know best standards in the situation.